### PR TITLE
Made ASE interface aware of FixAtoms constraints

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,12 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 
+[weakdeps]
+PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
+
+[extensions]
+AdvancedASEFunctions = "PyCall"
+
 [compat]
 FastGaussQuadrature = "0.4, 0.5, 1"
 ForwardDiff = "0.10"
@@ -30,7 +36,7 @@ Requires = "1"
 StaticArrays = "1"
 Unitful = "1"
 UnitfulAtomic = "1"
-julia = "1.7"
+julia = "≥1.9"
 
 [extras]
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"

--- a/ext/AdvancedASEFunctions.jl
+++ b/ext/AdvancedASEFunctions.jl
@@ -11,7 +11,7 @@ function NQCModels.mobileatoms(model::NQCModels.AdiabaticModels.AdiabaticASEMode
 	if length(ase_constraints) == 0
         return 1:length(model.atoms)
 	else
-        return symdiff(1:length(model.atoms), [constraint.get_indices() .+ 1 for constraint in constraints]...)
+        return symdiff(1:length(model.atoms), [constraint.get_indices() .+ 1 for constraint in ase_constraints]...)
     end
 end
 

--- a/ext/AdvancedASEFunctions.jl
+++ b/ext/AdvancedASEFunctions.jl
@@ -1,19 +1,13 @@
 module AdvancedASEFunctions
 using NQCModels, PyCall
 
-const ase = PyNULL()
-
-function __init__()
-    copy!(ase, pyimport("ase"))
-end
 
 """
 This module contains methods related to the NQCModels ASE interface that need access to Python types. (e.g. constraint checking)
 """
 
 function NQCModels.mobileatoms(model::NQCModels.AdiabaticModels.AdiabaticASEModel, n::Int)
-	constraints_FixAtoms=isa.(model.atoms.constraints, typeof(ase.constraints.FixAtoms))
-	ase_constraints = [constraint for constraint in model.atoms.constraints[constraints_FixAtoms]]
+	ase_constraints = [constraint for constraint in model.atoms.constraints]
 	if length(ase_constraints) == 0
         return 1:length(model.atoms)
 	else

--- a/ext/AdvancedASEFunctions.jl
+++ b/ext/AdvancedASEFunctions.jl
@@ -1,0 +1,14 @@
+module AdvancedASEFunctions
+using NQCModels, PyCall
+
+"""
+This module contains methods related to the NQCModels ASE interface that need access to Python types. (e.g. constraint checking) 
+"""
+
+function NQCModels.mobileatoms(model::NQCModels.AdiabaticModels.AdiabaticASEModel, n::Int)
+	ase=pyimport("ase")
+	constraints_FixAtoms=isa.(model.atoms.constraints, typeof(ase.constraints.FixAtoms))
+	return symdiff(1:length(model.atoms), [constraint.get_indices() .+ 1 for constraint in model.atoms.constraints[constraints_FixAtoms]]...)
+end
+
+end

--- a/ext/AdvancedASEFunctions.jl
+++ b/ext/AdvancedASEFunctions.jl
@@ -1,14 +1,24 @@
 module AdvancedASEFunctions
 using NQCModels, PyCall
 
+const ase = PyNULL()
+
+function __init__()
+    copy!(ase, pyimport("ase"))
+end
+
 """
-This module contains methods related to the NQCModels ASE interface that need access to Python types. (e.g. constraint checking) 
+This module contains methods related to the NQCModels ASE interface that need access to Python types. (e.g. constraint checking)
 """
 
 function NQCModels.mobileatoms(model::NQCModels.AdiabaticModels.AdiabaticASEModel, n::Int)
-	ase=pyimport("ase")
 	constraints_FixAtoms=isa.(model.atoms.constraints, typeof(ase.constraints.FixAtoms))
-	return symdiff(1:length(model.atoms), [constraint.get_indices() .+ 1 for constraint in model.atoms.constraints[constraints_FixAtoms]]...)
+	ase_constraints = [constraint for constraint in model.atoms.constraints[constraints_FixAtoms]]
+	if length(ase_constraints) == 0
+        return 1:length(model.atoms)
+	else
+        return symdiff(1:length(model.atoms), [constraint.get_indices() .+ 1 for constraint in constraints]...)
+    end
 end
 
 end


### PR DESCRIPTION
Fixes #29 and is a step toward handling frozen atoms at an NQCD-wide level. Combine with https://github.com/NQCD/NQCDistributions.jl/issues/12 and https://github.com/NQCD/NQCDistributions.jl/issues/9 to handle zero initial velocities for frozen atoms in a structure. 