### PR TITLE
Insert of coupling_rescale in wide_band_bath_discretisation.jl

### DIFF
--- a/src/diabatic/anderson_holstein.jl
+++ b/src/diabatic/anderson_holstein.jl
@@ -8,11 +8,11 @@ struct AndersonHolstein{M<:DiabaticModel,B,D,T} <: LargeDiabaticModel
     coupling_rescale::Real
 end
 
-function AndersonHolstein(model, bath; fermi_level=0.0, coupling_rescale=1.0)
+function AndersonHolstein(model, bath; fermi_level=0.0, couplings_rescale=1.0)
     tmp_derivative = Ref(NQCModels.zero_derivative(model, zeros(1,1)))
     fermi_level = austrip(fermi_level)
     nelectrons = count(x -> x <= fermi_level, bath.bathstates)
-    return AndersonHolstein(model, bath, tmp_derivative, fermi_level, nelectrons, coupling_rescale)
+    return AndersonHolstein(model, bath, tmp_derivative, fermi_level, nelectrons, couplings_rescale)
 end
 
 NQCModels.nstates(model::AndersonHolstein) = NQCModels.nstates(model.bath) + 1

--- a/src/diabatic/anderson_holstein.jl
+++ b/src/diabatic/anderson_holstein.jl
@@ -5,7 +5,7 @@ struct AndersonHolstein{M<:DiabaticModel,B,D,T} <: LargeDiabaticModel
     tmp_derivative::Base.RefValue{D}
     fermi_level::T
     nelectrons::Int
-    coupling_rescale::Real
+    couplings_rescale::Real
 end
 
 function AndersonHolstein(model, bath; fermi_level=0.0, couplings_rescale=1.0)
@@ -24,7 +24,7 @@ function NQCModels.potential!(model::AndersonHolstein, V::Hermitian, r::Abstract
     Vsystem = NQCModels.potential(model.model, r)
     V[1,1] = Vsystem[2,2] - Vsystem[1,1]
     fillbathstates!(V, model.bath)
-    fillbathcoupling!(V, Vsystem[2,1], model.bath, model.coupling_rescale)
+    fillbathcoupling!(V, Vsystem[2,1], model.bath, model.couplings_rescale)
     return V
 end
 
@@ -33,7 +33,7 @@ function NQCModels.derivative!(model::AndersonHolstein, D::AbstractMatrix{<:Herm
     
     for I in eachindex(Dsystem, D)
         D[I][1,1] = Dsystem[I][2,2] - Dsystem[I][1,1]
-        fillbathcoupling!(D[I], Dsystem[I][2,1], model.bath, model.coupling_rescale)
+        fillbathcoupling!(D[I], Dsystem[I][2,1], model.bath, model.couplings_rescale)
     end
 
     return D

--- a/src/diabatic/anderson_holstein.jl
+++ b/src/diabatic/anderson_holstein.jl
@@ -5,13 +5,14 @@ struct AndersonHolstein{M<:DiabaticModel,B,D,T} <: LargeDiabaticModel
     tmp_derivative::Base.RefValue{D}
     fermi_level::T
     nelectrons::Int
+    coupling_rescale::Real
 end
 
-function AndersonHolstein(model, bath; fermi_level=0.0)
+function AndersonHolstein(model, bath; fermi_level=0.0, coupling_rescale=1.0)
     tmp_derivative = Ref(NQCModels.zero_derivative(model, zeros(1,1)))
     fermi_level = austrip(fermi_level)
     nelectrons = count(x -> x <= fermi_level, bath.bathstates)
-    return AndersonHolstein(model, bath, tmp_derivative, fermi_level, nelectrons)
+    return AndersonHolstein(model, bath, tmp_derivative, fermi_level, nelectrons, coupling_rescale)
 end
 
 NQCModels.nstates(model::AndersonHolstein) = NQCModels.nstates(model.bath) + 1
@@ -23,7 +24,7 @@ function NQCModels.potential!(model::AndersonHolstein, V::Hermitian, r::Abstract
     Vsystem = NQCModels.potential(model.model, r)
     V[1,1] = Vsystem[2,2] - Vsystem[1,1]
     fillbathstates!(V, model.bath)
-    fillbathcoupling!(V, Vsystem[2,1], model.bath)
+    fillbathcoupling!(V, Vsystem[2,1], model.bath, model.coupling_rescale)
     return V
 end
 
@@ -32,7 +33,7 @@ function NQCModels.derivative!(model::AndersonHolstein, D::AbstractMatrix{<:Herm
     
     for I in eachindex(Dsystem, D)
         D[I][1,1] = Dsystem[I][2,2] - Dsystem[I][1,1]
-        fillbathcoupling!(D[I], Dsystem[I][2,1], model.bath)
+        fillbathcoupling!(D[I], Dsystem[I][2,1], model.bath, model.coupling_rescale)
     end
 
     return D

--- a/src/diabatic/wide_band_bath_discretisation.jl
+++ b/src/diabatic/wide_band_bath_discretisation.jl
@@ -8,18 +8,18 @@ function fillbathstates!(out::Hermitian, bath::WideBandBathDiscretisation)
     copy!(diagonal, bath.bathstates)
 end
 
-function fillbathcoupling!(out::Hermitian, coupling::Real, bath::WideBandBathDiscretisation, coupling_rescale)
+function fillbathcoupling!(out::Hermitian, coupling::Real, bath::WideBandBathDiscretisation, coupling_rescale::Real=1.0)
     first_column = @view out.data[2:end, 1]
     setcoupling!(first_column, bath.bathcoupling, coupling, coupling_rescale)
     first_row = @view out.data[1, 2:end]
     copy!(first_row, first_column)
 end
 
-function setcoupling!(out::AbstractVector, bathcoupling::AbstractVector, coupling::Real, coupling_rescale)
+function setcoupling!(out::AbstractVector, bathcoupling::AbstractVector, coupling::Real, coupling_rescale::Real=1.0)
     out .= bathcoupling .* coupling .* coupling_rescale
 end
 
-function setcoupling!(out::AbstractVector, bathcoupling::Real, coupling::Real, coupling_rescale)
+function setcoupling!(out::AbstractVector, bathcoupling::Real, coupling::Real, coupling_rescale::Real=1.0)
     fill!(out, bathcoupling * coupling .* coupling_rescale)
 end
 

--- a/src/diabatic/wide_band_bath_discretisation.jl
+++ b/src/diabatic/wide_band_bath_discretisation.jl
@@ -16,7 +16,7 @@ function fillbathcoupling!(out::Hermitian, coupling::Real, bath::WideBandBathDis
 end
 
 function setcoupling!(out::AbstractVector, bathcoupling::AbstractVector, coupling::Real, couplings_rescale::Real=1.0)
-    out .= bathcoupling .* coupling .* couplings_rescale
+    out .= bathcoupling .* coupling .* couplings_rescale  # bath's states coupling (constant) * Hybridization coupling component V_k(r)
 end
 
 function setcoupling!(out::AbstractVector, bathcoupling::Real, coupling::Real, couplings_rescale::Real=1.0)

--- a/src/diabatic/wide_band_bath_discretisation.jl
+++ b/src/diabatic/wide_band_bath_discretisation.jl
@@ -8,19 +8,19 @@ function fillbathstates!(out::Hermitian, bath::WideBandBathDiscretisation)
     copy!(diagonal, bath.bathstates)
 end
 
-function fillbathcoupling!(out::Hermitian, coupling::Real, bath::WideBandBathDiscretisation)
+function fillbathcoupling!(out::Hermitian, coupling::Real, bath::WideBandBathDiscretisation, coupling_rescale)
     first_column = @view out.data[2:end, 1]
-    setcoupling!(first_column, bath.bathcoupling, coupling)
+    setcoupling!(first_column, bath.bathcoupling, coupling, coupling_rescale)
     first_row = @view out.data[1, 2:end]
     copy!(first_row, first_column)
 end
 
-function setcoupling!(out::AbstractVector, bathcoupling::AbstractVector, coupling::Real)
-    out .= bathcoupling .* coupling
+function setcoupling!(out::AbstractVector, bathcoupling::AbstractVector, coupling::Real, coupling_rescale)
+    out .= bathcoupling .* coupling .* coupling_rescale
 end
 
-function setcoupling!(out::AbstractVector, bathcoupling::Real, coupling::Real)
-    fill!(out, bathcoupling * coupling)
+function setcoupling!(out::AbstractVector, bathcoupling::Real, coupling::Real, coupling_rescale)
+    fill!(out, bathcoupling * coupling .* coupling_rescale)
 end
 
 """

--- a/src/diabatic/wide_band_bath_discretisation.jl
+++ b/src/diabatic/wide_band_bath_discretisation.jl
@@ -20,7 +20,7 @@ function setcoupling!(out::AbstractVector, bathcoupling::AbstractVector, couplin
 end
 
 function setcoupling!(out::AbstractVector, bathcoupling::Real, coupling::Real, couplings_rescale::Real=1.0)
-    fill!(out, bathcoupling * coupling .* couplings_rescale)
+    fill!(out, bathcoupling * coupling * couplings_rescale)
 end
 
 """

--- a/src/diabatic/wide_band_bath_discretisation.jl
+++ b/src/diabatic/wide_band_bath_discretisation.jl
@@ -8,19 +8,19 @@ function fillbathstates!(out::Hermitian, bath::WideBandBathDiscretisation)
     copy!(diagonal, bath.bathstates)
 end
 
-function fillbathcoupling!(out::Hermitian, coupling::Real, bath::WideBandBathDiscretisation, coupling_rescale::Real=1.0)
+function fillbathcoupling!(out::Hermitian, coupling::Real, bath::WideBandBathDiscretisation, couplings_rescale::Real=1.0)
     first_column = @view out.data[2:end, 1]
-    setcoupling!(first_column, bath.bathcoupling, coupling, coupling_rescale)
+    setcoupling!(first_column, bath.bathcoupling, coupling, couplings_rescale)
     first_row = @view out.data[1, 2:end]
     copy!(first_row, first_column)
 end
 
-function setcoupling!(out::AbstractVector, bathcoupling::AbstractVector, coupling::Real, coupling_rescale::Real=1.0)
-    out .= bathcoupling .* coupling .* coupling_rescale
+function setcoupling!(out::AbstractVector, bathcoupling::AbstractVector, coupling::Real, couplings_rescale::Real=1.0)
+    out .= bathcoupling .* coupling .* couplings_rescale
 end
 
-function setcoupling!(out::AbstractVector, bathcoupling::Real, coupling::Real, coupling_rescale::Real=1.0)
-    fill!(out, bathcoupling * coupling .* coupling_rescale)
+function setcoupling!(out::AbstractVector, bathcoupling::Real, coupling::Real, couplings_rescale::Real=1.0)
+    fill!(out, bathcoupling * coupling .* couplings_rescale)
 end
 
 """

--- a/test/wide_band_bath_discretisations.jl
+++ b/test/wide_band_bath_discretisations.jl
@@ -8,10 +8,11 @@ using LinearAlgebra: Hermitian, diagind
     bath = NQCModels.TrapezoidalRule(50, -10, 10)
     n = NQCModels.nstates(bath)
     out = Hermitian(zeros(n+1, n+1))
+    coupling_rescale = 1.0
 
     NQCModels.DiabaticModels.fillbathstates!(out, bath)
     @test all(out[diagind(out)[2:end]] .== bath.bathstates)
-    NQCModels.DiabaticModels.fillbathcoupling!(out, 1.0, bath)
+    NQCModels.DiabaticModels.fillbathcoupling!(out, 1.0, bath, coupling_rescale)
     @test all(isapprox.(out[1,2:end], 1.0 / sqrt(50/20)))
     @test all(isapprox.(out[2:end,1], 1.0 / sqrt(50/20)))
 end
@@ -21,9 +22,10 @@ end
 
     n = NQCModels.nstates(bath)
     out = Hermitian(zeros(n+1, n+1))
+    coupling_rescale = 1.0
 
     NQCModels.DiabaticModels.fillbathstates!(out, bath)
-    NQCModels.DiabaticModels.fillbathcoupling!(out, 1.0, bath)
+    NQCModels.DiabaticModels.fillbathcoupling!(out, 1.0, bath, coupling_rescale)
 end
 
 @testset "ReferenceGaussLegendre" begin
@@ -31,9 +33,10 @@ end
 
     n = NQCModels.nstates(bath)
     out = Hermitian(zeros(n+1, n+1))
+    coupling_rescale = 1.0
 
     NQCModels.DiabaticModels.fillbathstates!(out, bath)
-    NQCModels.DiabaticModels.fillbathcoupling!(out, 1.0, bath)
+    NQCModels.DiabaticModels.fillbathcoupling!(out, 1.0, bath, coupling_rescale)
 end
 
 @testset "FullGaussLegendre" begin
@@ -41,7 +44,8 @@ end
 
     n = NQCModels.nstates(bath)
     out = Hermitian(zeros(n+1, n+1))
+    coupling_rescale = 1.0
 
     NQCModels.DiabaticModels.fillbathstates!(out, bath)
-    NQCModels.DiabaticModels.fillbathcoupling!(out, 1.0, bath)
+    NQCModels.DiabaticModels.fillbathcoupling!(out, 1.0, bath, coupling_rescale)
 end

--- a/test/wide_band_bath_discretisations.jl
+++ b/test/wide_band_bath_discretisations.jl
@@ -8,11 +8,11 @@ using LinearAlgebra: Hermitian, diagind
     bath = NQCModels.TrapezoidalRule(50, -10, 10)
     n = NQCModels.nstates(bath)
     out = Hermitian(zeros(n+1, n+1))
-    coupling_rescale = 1.0
+    couplings_rescale = 1.0
 
     NQCModels.DiabaticModels.fillbathstates!(out, bath)
     @test all(out[diagind(out)[2:end]] .== bath.bathstates)
-    NQCModels.DiabaticModels.fillbathcoupling!(out, 1.0, bath, coupling_rescale)
+    NQCModels.DiabaticModels.fillbathcoupling!(out, 1.0, bath, couplings_rescale)
     @test all(isapprox.(out[1,2:end], 1.0 / sqrt(50/20)))
     @test all(isapprox.(out[2:end,1], 1.0 / sqrt(50/20)))
 end
@@ -22,10 +22,10 @@ end
 
     n = NQCModels.nstates(bath)
     out = Hermitian(zeros(n+1, n+1))
-    coupling_rescale = 1.0
+    couplings_rescale = 1.0
 
     NQCModels.DiabaticModels.fillbathstates!(out, bath)
-    NQCModels.DiabaticModels.fillbathcoupling!(out, 1.0, bath, coupling_rescale)
+    NQCModels.DiabaticModels.fillbathcoupling!(out, 1.0, bath, couplings_rescale)
 end
 
 @testset "ReferenceGaussLegendre" begin
@@ -33,10 +33,10 @@ end
 
     n = NQCModels.nstates(bath)
     out = Hermitian(zeros(n+1, n+1))
-    coupling_rescale = 1.0
+    couplings_rescale = 1.0
 
     NQCModels.DiabaticModels.fillbathstates!(out, bath)
-    NQCModels.DiabaticModels.fillbathcoupling!(out, 1.0, bath, coupling_rescale)
+    NQCModels.DiabaticModels.fillbathcoupling!(out, 1.0, bath, couplings_rescale)
 end
 
 @testset "FullGaussLegendre" begin
@@ -44,8 +44,8 @@ end
 
     n = NQCModels.nstates(bath)
     out = Hermitian(zeros(n+1, n+1))
-    coupling_rescale = 1.0
+    couplings_rescale = 1.0
 
     NQCModels.DiabaticModels.fillbathstates!(out, bath)
-    NQCModels.DiabaticModels.fillbathcoupling!(out, 1.0, bath, coupling_rescale)
+    NQCModels.DiabaticModels.fillbathcoupling!(out, 1.0, bath, couplings_rescale)
 end


### PR DESCRIPTION
Introduction of the keyword 'coupling_rescale' in 'fillbathcouplings!',  'setcoupling!' and in NewnsAnderson models. This allows the coupling in a 2x2 'model' to be rescaled such that the discretized NAH has the same ground state energy landscape as the 2x2 'model'.

For now, this optional coupling_rescale parameter will be a global scalar, but in the future, we will change this to a coordinate-dependent scaling function.