### PR TITLE
fix to spin boson in place potential function

### DIFF
--- a/src/quantum_models/spin_boson.jl
+++ b/src/quantum_models/spin_boson.jl
@@ -111,10 +111,10 @@ function NQCModels.potential!(model::SpinBoson, V::Hermitian, r::AbstractMatrix)
     v0 = sum(temp)
 
     V11 = v0 + ϵ
-    V11 += sum(cⱼ .* r)
+    V11 += sum(cⱼ'.* r)
     
     V22 = v0 - ϵ
-    V22 -= sum(cⱼ .* r)
+    V22 -= sum(cⱼ'.* r)
 
     V12 = Δ
 


### PR DESCRIPTION
Added `'` to `c_j` variables in the Spin Boson model in-place potential!() function such that it matched non-inplace potential function 